### PR TITLE
Slightly more performance during build

### DIFF
--- a/packages-available/ColouredWeb/build.achel
+++ b/packages-available/ColouredWeb/build.achel
@@ -34,18 +34,18 @@ singleStringNow preview.md
 
 
 debug 0,Building sheets.
-# Loop through colours.
-retrieveResults ColouredWeb,colours
+# Loop through the themeShades
+retrieveResults ColouredWeb,themeShades
 loop
-	set Local,hexColour,~!Result,line!~
+	set Local,theme,~!Result,key!~
+	
+	useTheme ~!Local,theme!~
 	
 	isolate
-		# Loop through the themeShades
-		retrieveResults ColouredWeb,themeShades
+		# Loop through colours.
+		retrieveResults ColouredWeb,colours
 		loop
-			set Local,theme,~!Result,key!~
-			
-			useTheme ~!Local,theme!~
+			set Local,hexColour,~!Result,line!~
 			
 			# Figure out the paths.
 			set Local,fileOut,~!Local,cssDir!~/~!Local,theme!~-~!Local,hexColour!~.css


### PR DESCRIPTION
## Results

Before

```
real    0m4,553s
```

After
```
real    0m3,763s
```

## Why

When I was doing the re-write, I switched two nested loops to make them
compatible with the preview.md generation. I later separated out the
preview.md generation since it's really quick to do, but I never
switched the loops back.

It matters because the inner loop was much heavier than the outer loop.
So switching them achieves the same result with less effort.