### PR TITLE
Fix sed's new lines handling

### DIFF
--- a/apps/kmail/bin/filter/insertSheet
+++ b/apps/kmail/bin/filter/insertSheet
@@ -13,7 +13,7 @@ filterInsertSheet="s/<head><!-- Inserted stylesheet using kmailMessageDarkMode.*
 # color:#000000;background-color:#FFFFFF
 
 # Fix new lines so that the following patterns won't get broken and fail to match.
-fixNewLines=':begin;$!N;s/=\n//;tbegin'
+fixNewLines=':a;$!{N;s/([^?])=\n([^M][^I][^M][^E])/\1\2/;ba;}'
 
 # Make bgcolor the same as color, then remove it. The first step saves duplication. 
 reduceTheStuffWeNeedToMatch="s/\\(bgcolor\\|background-color\\|background\\)/color/g"
@@ -76,7 +76,7 @@ esac
 # Run the filter only if it is not disabled.
 if [ "$filterMethod" != 'disable' ]; then
     if [ "$shouldFixNewLines" == 'true' ]; then
-        sed "s/=3D/=/g;" | sed "$fixNewLines" | sed "$filter"
+        sed "s/=3D/=/g;" | sed -E "$fixNewLines" | sed "$filter"
     else
         sed "$filter"
     fi

--- a/apps/kmail/shest/unit/filter/05shouldNotBreakMime
+++ b/apps/kmail/shest/unit/filter/05shouldNotBreakMime
@@ -1,0 +1,23 @@
+#!/bin/bash
+# Test to make sure the MIME declaration doesn't get appended to the previous line.
+
+. "$SHEST_SCRIPT" "--doNothing"
+
+testString="         epHA==
+MIME-Version: 1.0"
+expectedResult="         epHA==
+MIME-Version: 1.0"
+
+FILTER_METHOD='all'
+# Piped through itself a few times, because it has to be able to be re-run non-destructively.
+result="$(echo "$testString" | ./bin/filter/insertSheet | ./bin/filter/insertSheet | ./bin/filter/insertSheet 2>&1)"
+exitCode=$?
+
+
+if [ "$exitCode" != "0" ]; then
+    fail "Got value=\"$result\" and exit code=$exitCode."
+elif [ "$result" != "$expectedResult" ]; then
+    fail "Expected \"$expectedResult\", but got \"$result\"."
+else
+    pass "Great!"
+fi

--- a/apps/kmail/shest/unit/filter/06shouldNotBreakFrom
+++ b/apps/kmail/shest/unit/filter/06shouldNotBreakFrom
@@ -1,0 +1,25 @@
+#!/bin/bash
+# Test that the from field doesn't get appended to the previous line.
+
+. "$SHEST_SCRIPT" "--doNothing"
+
+testString="Subject: =?UTF-8?Q?New_reply_to_a_comment_on_=E2=80=98Thing?=
+	=?UTF-8?Q?Thing=21=E2=80=99?=
+From: YouTube <noreply@youtube.com>"
+expectedResult="Subject: =?UTF-8?Q?New_reply_to_a_comment_on_=E2=80=98Thing?=
+	=?UTF-8?Q?Thing=21=E2=80=99?=
+From: YouTube <noreply@youtube.com>"
+
+FILTER_METHOD='all'
+# Piped through itself a few times, because it has to be able to be re-run non-destructively.
+result="$(echo "$testString" | ./bin/filter/insertSheet | ./bin/filter/insertSheet | ./bin/filter/insertSheet 2>&1)"
+exitCode=$?
+
+
+if [ "$exitCode" != "0" ]; then
+    fail "Got value=\"$result\" and exit code=$exitCode."
+elif [ "$result" != "$expectedResult" ]; then
+    fail "Expected \"$expectedResult\", but got \"$result\"."
+else
+    pass "Great!"
+fi


### PR DESCRIPTION
## What

This is a slightly more aggressive approach to fixing the new lines, but it also has some added safety to not munch critical fields.

## Why 

The problem it fixes is that sed was missing some new lines that split important words during the time we were searching for them. This catches the remaining cases I've found so far.

## Notes

It's possible something could get caught that shouldn't. The result of this is that a line will be appended that shouldn't be. If that happens

* I can add protection and tests against that. 
* Please file [an issue](https://github.com/ksandom/colouredWeb/issues) detailing
  * what code got munched. (show before and after. You can get this be reproducing the issue on another email from the same vendor.)
  * what the side-effect was. Eg only shows plain-text message. Subject is missing. Sender is missing. etc.