### PR TITLE
Don't munge anything other than HTML

### DIFF
--- a/apps/kmail/bin/filter/insertSheet
+++ b/apps/kmail/bin/filter/insertSheet
@@ -12,9 +12,6 @@ filterInsertSheet="s/<head><!-- Inserted stylesheet using kmailMessageDarkMode.*
 # As it currently is. The following not currently be undone A work around could be to replace these with non-existent attributes. Eg "color=" -> "disabledColor=". I haven't yet tested whether this will silently fail, and be fine. Or this will create more problems than it will solve.
 # color:#000000;background-color:#FFFFFF
 
-# Fix new lines so that the following patterns won't get broken and fail to match.
-fixNewLines=':a;$!{N;s/([^?])=\n([^M][^I][^M][^E])/\1\2/;ba;}'
-
 # Make bgcolor the same as color, then remove it. The first step saves duplication. 
 reduceTheStuffWeNeedToMatch="s/\\(bgcolor\\|background-color\\|background\\)/color/g"
 
@@ -73,10 +70,51 @@ case "$filterMethod" in
     ;;
 esac
 
+function doFilter
+{
+    sed "s/=3D/=/g;" | sed "$filter"
+}
+
 # Run the filter only if it is not disabled.
 if [ "$filterMethod" != 'disable' ]; then
     if [ "$shouldFixNewLines" == 'true' ]; then
-        sed "s/=3D/=/g;" | sed -E "$fixNewLines" | sed "$filter"
+        useMunger=0
+        mungeBuffer=''
+        while IFS= read -r line;do
+            if [[ "$line" =~ \<[Hh][Ee][Aa][Dd] ]] || [[ "$line" =~ \<[Bb][Oo][Dd][Yy] ]]; then
+                # Turn it on.
+                useMunger=1
+            fi
+            if [[ "$line" =~ \</[Bb][Oo][Dd][Yy] ]] || [[ "$line" =~ \</[Hh][Tt][Mm][Ll] ]]; then
+                # Turn it off after this iteration. This is to handle one-liners.
+                useMunger=2
+            fi
+            
+            if [ "$useMunger" != 0 ]; then
+                # Munge the input.
+                if [ "${line: -1}" ==  '=' ]; then
+                    mungeBuffer="${mungeBuffer}${line::-1}"
+                else
+                    mungeBuffer="${mungeBuffer}${line}\n"
+                fi
+            else
+                echo "$line"
+            fi
+            
+            
+            if [ "$useMunger" == 2 ]; then
+                # Turn off the munger now that we have finished this iteration, and send it through thefilter.
+                useMunger=0
+                echo -ne "$mungeBuffer" | doFilter
+                mungeBuffer=''
+            fi
+        done
+        
+        if [ "$mungeBuffer" != '' ]; then
+            # If we get here, there is still stuff left in the mungeBuffer, This could be that the closing tags are missing in the email. Or it could be a bug in this code.
+            echo "<!-- ColouredWeb: Munge failure 000 - begin -->$mungeBuffer<!-- ColouredWeb: Munge failure 000 - end -->" | doFilter
+            echo "<!-- ColouredWeb: Munge failure 000 - appendix -->"
+        fi
     else
         sed "$filter"
     fi

--- a/apps/kmail/shest/unit/filter/01insertHead
+++ b/apps/kmail/shest/unit/filter/01insertHead
@@ -3,7 +3,7 @@
 
 . "$SHEST_SCRIPT" "--doNothing"
 
-testString='blah<head>wheee'
+testString='blah<head>wheee</body>'
 
 FILTER_METHOD='all'
 # Piped through itself a few times, because it has to be able to be re-run non-destructively.
@@ -16,8 +16,8 @@ elif ! echo "$result" | grep -q '/var/lib/kmailMessageDarkMode/custom.css'; then
     fail "The stylesheet doesn't appear to have been inserted: \"$result\"."
 elif ! echo "$result" | grep -q '^blah<head>'; then
     fail "We seem to have lost the beginning of the contents."
-elif ! echo "$result" | grep -q 'wheee$'; then
-    fail "We seem to have lost the endging of the contents."
+elif ! echo "$result" | grep -q 'wheee</body>$'; then
+    fail "We seem to have lost the ending of the contents."
 else
     pass "Great!"
 fi

--- a/apps/kmail/shest/unit/filter/02stripColours
+++ b/apps/kmail/shest/unit/filter/02stripColours
@@ -3,8 +3,8 @@
 
 . "$SHEST_SCRIPT" "--doNothing"
 
-testString="<span style=\"font-family:'Calibri';font-size:11pt;color:#000000;background-color:#FFFFFF;color:#FFFFFF\"><font color=\"#a1a2a3\"  color='#a1a2a3'  color =\"#a1a2a3\"  color= \"#a1a2a3\" color = \"#a1a2a3\" bgcolor=\"#C2C3C1\" color=\"#d9213e\"><span style=\"color:white ; color:bright-blue ; color: bright-blue;background:white;color:gray\"><font color=\"#d9213e\">"
-expectedResult="<span style=\"font-family:'Calibri';font-size:11pt;;;\"><font          ><span style=\" ;  ; ;;\"><font >"
+testString="<body><span style=\"font-family:'Calibri';font-size:11pt;color:#000000;background-color:#FFFFFF;color:#FFFFFF\"><font color=\"#a1a2a3\"  color='#a1a2a3'  color =\"#a1a2a3\"  color= \"#a1a2a3\" color = \"#a1a2a3\" bgcolor=\"#C2C3C1\" color=\"#d9213e\"><span style=\"color:white ; color:bright-blue ; color: bright-blue;background:white;color:gray\"><font color=\"#d9213e\"></body>"
+expectedResult="<body><span style=\"font-family:'Calibri';font-size:11pt;;;\"><font          ><span style=\" ;  ; ;;\"><font ></body>"
 
 FILTER_METHOD='all'
 # Piped through itself a few times, because it has to be able to be re-run non-destructively.

--- a/apps/kmail/shest/unit/filter/04equals3D
+++ b/apps/kmail/shest/unit/filter/04equals3D
@@ -3,8 +3,8 @@
 
 . "$SHEST_SCRIPT" "--doNothing"
 
-testString="thing=3Dblah"
-expectedResult="thing=blah"
+testString="<body>thing=3Dblah</HTML>"
+expectedResult="<body>thing=blah</HTML>"
 
 FILTER_METHOD='all'
 # Piped through itself a few times, because it has to be able to be re-run non-destructively.

--- a/apps/kmail/shest/unit/filter/07shouldNotBreakFrom
+++ b/apps/kmail/shest/unit/filter/07shouldNotBreakFrom
@@ -1,11 +1,16 @@
 #!/bin/bash
-# Write a decription of the test here.
+# Test that the from field doesn't get appended to the previous line.
 
 . "$SHEST_SCRIPT" "--doNothing"
 
-testString="<body>thing=
-blah</body>"
-expectedResult="<body>thingblah</body>"
+testString="wee=
+waa=
+woo=
+From: "
+expectedResult="wee=
+waa=
+woo=
+From: "
 
 FILTER_METHOD='all'
 # Piped through itself a few times, because it has to be able to be re-run non-destructively.

--- a/apps/kmail/shest/unit/filter/08filterOnOff
+++ b/apps/kmail/shest/unit/filter/08filterOnOff
@@ -1,11 +1,23 @@
 #!/bin/bash
-# Write a decription of the test here.
+# Test that the from field doesn't get appended to the previous line.
 
 . "$SHEST_SCRIPT" "--doNothing"
 
-testString="<body>thing=
-blah</body>"
-expectedResult="<body>thingblah</body>"
+testString="wee=
+waa=
+woo=
+From: 
+<BODY>
+blah=
+ is yay
+</BODY>"
+expectedResult="wee=
+waa=
+woo=
+From: 
+<BODY>
+blah is yay
+</BODY>"
 
 FILTER_METHOD='all'
 # Piped through itself a few times, because it has to be able to be re-run non-destructively.


### PR DESCRIPTION
## What

A complete re-write of the code the does the filtering. Before the whole email was piped through sed, blindly applying the filters to the whole thing. Now it's surgically only modifying the HTML.

## Why

Stuff was matching that shouldn't have been. This was causing meta data about the email to appear to be missing.

## Notes

This will be slower than the old solution. But should already be scaling better than the old solution. The old solution would have gotten much, much slower as I refined it to cope with all the edge cases. This should simply avoid all of those edge cases all-together.